### PR TITLE
Match the project key against the exclude regex

### DIFF
--- a/cmd/zoekt-mirror-bitbucket-server/main.go
+++ b/cmd/zoekt-mirror-bitbucket-server/main.go
@@ -131,7 +131,7 @@ func main() {
 
 	trimmed := repos[:0]
 	for _, r := range repos {
-		if filter.Include(r.Slug) && (*projectType == "" || r.Project.Type == *projectType) {
+		if (filter.Include(r.Slug) || filter.Include(r.Project.Key)) && (*projectType == "" || r.Project.Type == *projectType) {
 			trimmed = append(trimmed, r)
 		}
 	}


### PR DESCRIPTION
The exclude match for Bitbucket was only matching against the
repository slug and not project key. This change forces the
exclude match to match against both.